### PR TITLE
Implement reduce (<) and multiple fields (+) operators

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,9 @@ const Symbols = {
   CHAR: 'CHAR',
   EXP: 'EXP',
   NONE: 'NONE',
-  INTEGER: 'INTEGER'
+  INTEGER: 'INTEGER',
+  PLUS: '+',
+  REDUCE: '<'
 }
 
 const getToken = (path: string): string => {
@@ -24,6 +26,10 @@ const getToken = (path: string): string => {
       return Symbols.LBRACK
     case Symbols.RBRACK:
       return Symbols.RBRACK
+    case Symbols.PLUS:
+      return Symbols.PLUS
+    case Symbols.REDUCE:
+      return Symbols.REDUCE
     default:
       return Symbols.CHAR
   }
@@ -43,6 +49,8 @@ const parsePath = (root: Object, path: string = '') => {
       return parseRBrack(root, path)
     case Symbols.CHAR:
       return parseObjectField(root, path)
+    case Symbols.REDUCE:
+      return parsePath(root, path.slice(1))
     case Symbols.NONE:
       return root
   };
@@ -93,21 +101,43 @@ const parseDot = (root: Object, path: string = '') => {
 }
 
 const parseObjectField = (root: Object, path: string = '') => {
-  const signal = (c) => getToken(c) === Symbols.CHAR
-  const { scan: field, rest } = scanPathUntil(path, signal)
+  const signal = (c) => getToken(c) === Symbols.CHAR || getToken(c) === Symbols.PLUS
+  const { scan: fieldExpr, rest } = scanPathUntil(path, signal)
   let nextRoot
 
-  if (Array.isArray(root)) {
-    nextRoot = root.map(element => {
-      if (Object.prototype.hasOwnProperty.call(element, field)) {
-        return element[field]
-      }
-      throwPathDoesNotExistAt(path)
-    })
-  } else if (Object.prototype.hasOwnProperty.call(root, field)) {
-    nextRoot = root[field]
+  if (fieldExpr.includes(Symbols.PLUS)) {
+    const fields = fieldExpr.split(Symbols.PLUS)
+    const pick = (obj: any) => {
+      const res = {}
+      fields.forEach(f => {
+        if (Object.prototype.hasOwnProperty.call(obj, f)) {
+          res[f] = obj[f]
+        } else {
+          throwPathDoesNotExistAt(path)
+        }
+      })
+      return res
+    }
+
+    if (Array.isArray(root)) {
+      nextRoot = root.map(pick)
+    } else {
+      nextRoot = pick(root)
+    }
   } else {
-    throwPathDoesNotExistAt(path)
+    const field = fieldExpr
+    if (Array.isArray(root)) {
+      nextRoot = root.map(element => {
+        if (Object.prototype.hasOwnProperty.call(element, field)) {
+          return element[field]
+        }
+        throwPathDoesNotExistAt(path)
+      })
+    } else if (Object.prototype.hasOwnProperty.call(root, field)) {
+      nextRoot = root[field]
+    } else {
+      throwPathDoesNotExistAt(path)
+    }
   }
 
   return parsePath(nextRoot, rest)
@@ -128,7 +158,11 @@ const parseLBrack = <T>(root: T[], path: string) => {
       break
     }
     case Symbols.NONE: {
-      return root.map(element => parsePath(element, rest))
+      const result = root.map(element => parsePath(element, rest))
+      if (rest[1] === Symbols.REDUCE) {
+        return result.reduce((acc, val) => acc.concat(val), [])
+      }
+      return result
     }
     default: {
       const expression = subPath

--- a/tests/proposals.spec.ts
+++ b/tests/proposals.spec.ts
@@ -1,0 +1,39 @@
+import { expect } from 'chai'
+import { bget } from '../src'
+
+describe('bget: proposals', () => {
+  describe('reduce (<)', () => {
+    it('flattens out nested lists into single list', () => {
+      const nestedLists = [[{ name: 'tiger' }, { name: 'lion' }], [{ name: 'wolf' }, { name: 'dog' }]]
+      expect(bget(nestedLists, '[]<[]')).to.deep.equal([
+        { name: 'tiger' },
+        { name: 'lion' },
+        { name: 'wolf' },
+        { name: 'dog' }
+      ])
+    })
+
+    it('flattens and then allows further path traversal', () => {
+        const nestedLists = [[{ name: 'tiger' }, { name: 'lion' }], [{ name: 'wolf' }, { name: 'dog' }]]
+        expect(bget(nestedLists, '[]<[].name')).to.deep.equal(['tiger', 'lion', 'wolf', 'dog'])
+    })
+  })
+
+  describe('get multiple fields (+)', () => {
+    it('returns a mapping of items with multiple fields', () => {
+      const testList = [
+        { id: '1', name: 'first', extra: 'foo' },
+        { id: '2', name: 'second', extra: 'bar' }
+      ]
+      expect(bget(testList, '[].id+name')).to.deep.equal([
+        { id: '1', name: 'first' },
+        { id: '2', name: 'second' }
+      ])
+    })
+
+    it('works on a single object', () => {
+        const testObject = { id: '1', name: 'first', extra: 'foo' }
+        expect(bget(testObject, 'id+name')).to.deep.equal({ id: '1', name: 'first' })
+    })
+  })
+})


### PR DESCRIPTION
Implemented the incomplete functionality mentioned in the README.md:
- **reduce ('<')**: Allows flattening nested lists into a single list (e.g., `[]<[]`).
- **get multiple fields ('+')**: Allows returning a mapping of items with multiple fields (e.g., `fieldOne+fieldTwo`).

The implementation involved updating the recursive descent parser in `src/index.ts` to recognize the new symbols and handle the corresponding logic during traversal.
Tests were added to verify these features for both single objects and arrays.

---
*PR created automatically by Jules for task [6314157418655856256](https://jules.google.com/task/6314157418655856256) started by @rushil-patel*